### PR TITLE
Added optional frameId and frame props to draw a specifc frame

### DIFF
--- a/components/Excalidraw.vue
+++ b/components/Excalidraw.vue
@@ -18,6 +18,8 @@ const props = withDefaults(defineProps<{
   drawFilePath: string
   darkMode?: true
   background?: boolean
+  frameId?: string | null | undefined
+  frame?: string | null | undefined
 }>(), {
   darkMode: false,
   background: false,
@@ -43,8 +45,14 @@ const loadJsonAndExport = async ({ drawFilePath: path, darkMode = false, backgro
     const url = new URL(path, window.location.origin + import.meta.env.BASE_URL).href
     const json = await (await fetch(url)).json()
 
-    const svgElement = await ExcalidrawLib.exportToSvg({
+    const filterId = frameId ? frameId : (json.elements.find(e => e.type === "frame" && e.name === frame)?.id ?? null)
+    const filtered = filterId ? {
       ...json,
+      elements: json.elements.filter(e => e.frameId === filterId)
+    } : json
+
+    const svgElement = await ExcalidrawLib.exportToSvg({
+      ...filtered,
       appState: {
         ...(json.appState as any),
         exportWithDarkMode: darkMode,


### PR DESCRIPTION
Frames are, in my opinion, a very useful functionality of Excalidraw. They can be used to create a presentation, where each slide is a different frame.
It would be useful being able to do the same in this slidev addon, by adding the ability to only draw a specific frame on a slide.

This PR adds two optional props:
 * frameId: id of a drawing frame
 * frame: name of the frame

Using one or the other, the component will only draw the elements in the specified frame.